### PR TITLE
Add API wrapper for dataframe functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ For example, to find the minimum and average of "age" across all rows:
 
 ### Running SQL Queries Programmatically
 
-Register `people` as a table:
+Register `df` as a table named `people`:
 
-    $ people.registerTempTable("people")
+    $ df.registerTempTable("people")
 
 Run a SQL query:
 

--- a/lib/DataFrame.js
+++ b/lib/DataFrame.js
@@ -1,0 +1,475 @@
+'use strict';
+
+//var DataFrameWriter = require('./DataFrameWriter');
+var GroupedData = require('./GroupedData');
+var Row = require('./Row');
+
+class DataFrame {
+
+    constructor(jvm_obj, java) {
+        this.jvm_obj = jvm_obj;
+        this.java = java;
+    }
+
+    /**
+     * Returns a new [[DataFrame]] with with new specified column names.
+     * @param colNames - array of new column names
+     * @group basic
+     * @since 1.3.0
+     */
+    /* @scala.annotation.varargs */
+    toDF(...colNames /*: String* */) /*: DataFrame*/ {
+        var new_jvm_obj = this.jvm_obj.toDF(...colNames);
+        return new DataFrame(new_jvm_obj);
+    }
+
+    /**
+     * Returns all column names as an array.
+     * @group basic
+     * @since 1.3.0
+     */
+    columns() /*: Array[String]*/ {
+        return this.jvm_obj.columns();
+    }
+
+    /**
+     * Prints the schema to the console in a nice tree format.
+     * @group basic
+     * @since 1.3.0
+     */
+    printSchema() /*: Unit */ {
+        this.jvm_obj.printSchema();
+    }
+
+    /**
+     * Prints the plans (logical and physical) to the console for debugging purposes.
+     * @group basic
+     * @since 1.3.0
+     */
+    explain(extended=false /*: Boolean */) /*: Unit */ {
+        this.jvm_obj.explain(extended);
+    }
+
+    /**
+     * Returns true if the `collect` and `take` methods can be run locally
+     * (without any Spark executors).
+     * @group basic
+     * @since 1.3.0
+     */
+    isLocal() /*: Boolean*/ {
+        return this.jvm_obj.isLocal();
+    }
+
+    /**
+     * Displays the [[DataFrame]] in a tabular form. Strings more than 20 characters will be
+     * truncated, and all cells will be aligned right. For example:
+     * {{{
+     *   year  month AVG('Adj Close) MAX('Adj Close)
+     *   1980  12    0.503218        0.595103
+     *   1981  01    0.523289        0.570307
+     *   1982  02    0.436504        0.475256
+     *   1983  03    0.410516        0.442194
+     *   1984  04    0.450090        0.483521
+     * }}}
+     *
+     * @param numRows Number of rows to show
+     *
+     * @param truncate If true, strings more than 20 characters will
+     *              be truncated and all cells will be aligned right
+     *
+     * @group action
+     * @since 1.3.0
+     */
+    show(numRows=20 /*: Int */, truncate=true /*: Boolean */) /*: Unit */ {
+        this.jvm_obj.show(numRows, truncate);
+    }
+
+
+    /**
+     * Join with another [[DataFrame]].
+     *
+     * If no `col` is provided, does a Cartesian join. (Note that cartesian
+     * joins are very expensive without an extra filter that can be pushed
+     * down).
+     * If a column name (string) is provided, does an equi-join.
+     * If a column expression is provided, uses that as a join expression.
+     *
+     * The following performs
+     * a full outer join between `df1` and `df2`.
+     *   df1.join(df2, col("df1Key").equalTo(col("df2Key")), "outer");
+     *
+     * @param right Right side of the join.
+     * @param col Column name or join expression.
+     * @param joinType One of: `inner`, `outer`, `left_outer`, `right_outer`, `leftsemi`.
+     * @group dfops
+     * @since 1.3.0
+     */
+    join(right /*: DataFrame */, col=null /*: Column|String */, joinType="inner" /*: String*/) /*: DataFrame */ {
+        if (col === null) {
+            return new DataFrame(this.jvm_obj.join(right));
+        } else {
+            return new DataFrame(this.jvm_obj.join(right, col, joinType));
+        }
+    }
+
+    /**
+     * Returns a new [[DataFrame]] sorted by the specified column, all in ascending order.
+     * @group dfops
+     * @since 1.3.0
+     */
+    /* @scala.annotation.varargs */
+    sort(col /*: (Column | String) */, ...cols /*: (Column* | String*) */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.sort(col, ...cols));
+    }
+
+    /**
+     * Selects column based on the column name and return it as a [[Column]].
+     * Note that the column name can also reference to a nested column like `a.b`.
+     * @group dfops
+     * @since 1.3.0
+     */
+    col(colName /*: String */) /*: Column */ {
+        return this.jvm_obj.col(colName);
+    }
+
+    /**
+     * Selects a set of column based expressions.
+     *
+     * @group dfops
+     * @since 1.3.0
+     */
+    /* @scala.annotation.varargs */
+    select(...cols /*: (Column* | String*) */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.select(...cols));
+    }
+
+    /**
+     * Selects a set of SQL expressions. This is a variant of `select` that accepts
+     * SQL expressions.
+     *
+     * @group dfops
+     * @since 1.3.0
+     */
+    /* @scala.annotation.varargs */
+    selectExpr(...exprs /*: String* */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.selectExpr(...exprs));
+    }
+
+    /**
+     * Filters rows using the given column expression or SQL expression.
+     * {{{
+     *   // The following are equivalent:
+     *   peopleDf.filter(peopleDf.col("age").gt(15))
+     *   peopleDf.filter("age > 15")
+     * }}}
+     * @group dfops
+     * @since 1.3.0
+     */
+    filter(condition /*: Column|String */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.filter(condition));
+    }
+
+    /**
+     * Filters rows using the given condition. This is an alias for `filter`.
+     * @group dfops
+     * @since 1.3.0
+     */
+    where(condition /*: Column */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.filter(condition));
+    }
+
+    /**
+     * Groups the [[DataFrame]] using the specified columns, so we can run aggregation on them.
+     * See [[GroupedData]] for all the available aggregate functions.
+     *
+     * {{{
+     *   // Compute the average for all numeric columns grouped by department.
+     *   df.groupBy("department").avg()
+     *
+     * }}}
+     * @group dfops
+     * @since 1.3.0
+     */
+    /* @scala.annotation.varargs */
+    groupBy(...cols /*: (Column* | String*) */) /*: GroupedData */ {
+        return new GroupedData(this.jvm_obj.groupBy(...cols));
+    }
+
+    /**
+     * Create a multi-dimensional rollup for the current [[DataFrame]] using the specified columns,
+     * so we can run aggregation on them.
+     * See [[GroupedData]] for all the available aggregate functions.
+     *
+     * {{{
+     *   // Compute the average for all numeric columns rolluped by department and group.
+     *   df.rollup($"department", $"group").avg()
+     *
+     * }}}
+     * @group dfops
+     * @since 1.4.0
+     */
+    /* @scala.annotation.varargs */
+    rollup(...cols /*: (Column* | String*) */) /*: GroupedData */ {
+        return new GroupedData(this.jvm_obj.rollup(...cols));
+    }
+
+    /**
+     * Create a multi-dimensional cube for the current [[DataFrame]] using the specified columns,
+     * so we can run aggregation on them.
+     * See [[GroupedData]] for all the available aggregate functions.
+     *
+     * {{{
+     *   // Compute the average for all numeric columns cubed by department and group.
+     *   df.cube("department", "group").avg()
+     * }}}
+     * @group dfops
+     * @since 1.4.0
+     */
+    /* @scala.annotation.varargs */
+    cube(...cols /*: (Column*|String*) */) /*: GroupedData */ {
+        return new GroupedData(this.jvm_obj.cube(...cols));
+    }
+
+    /**
+     * Aggregates on the entire [[DataFrame]] without groups.
+     * {{{
+     *   // df.agg(...) is a shorthand for df.groupBy().agg(...)
+     *   df.agg(max("age"), avg("salary"))
+     *   df.groupBy().agg(max("age"), avg("salary"))
+     * }}}
+     * @group dfops
+     * @since 1.3.0
+     */
+    /* @scala.annotation.varargs */
+    agg(...cols /*: Column* */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.agg(...cols));
+    }
+
+    /**
+     * Returns a new [[DataFrame]] by taking the first `n` rows. The difference between this function
+     * and `head` is that `head` returns an array while `limit` returns a new [[DataFrame]].
+     * @group dfops
+     * @since 1.3.0
+     */
+    limit(n /*: Int */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.limit(n));
+    }
+
+    /**
+     * Returns a new [[DataFrame]] containing union of rows in this frame and another frame.
+     * This is equivalent to `UNION ALL` in SQL.
+     * @group dfops
+     * @since 1.3.0
+     */
+    unionAll(other /*: DataFrame */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.unionAll(other));
+    }
+
+    /**
+     * Returns a new [[DataFrame]] containing rows only in both this frame and another frame.
+     * This is equivalent to `INTERSECT` in SQL.
+     * @group dfops
+     * @since 1.3.0
+     */
+    intersect(other /*: DataFrame */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.intersect(other));
+    }
+
+    /**
+     * Returns a new [[DataFrame]] containing rows in this frame but not in another frame.
+     * This is equivalent to `EXCEPT` in SQL.
+     * @group dfops
+     * @since 1.3.0
+     */
+    except(other /*: DataFrame */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.except(other));
+    }
+
+    /**
+     * Returns a new [[DataFrame]] by sampling a fraction of rows, using a random seed.
+     *
+     * @param withReplacement Sample with replacement or not.
+     * @param fraction Fraction of rows to generate.
+     * @group dfops
+     * @since 1.3.0
+     */
+    sample(withReplacement /*: Boolean */, fraction /*: Double */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.sample(withReplacement, fraction));
+    }
+
+    /**
+     * Randomly splits this [[DataFrame]] with the provided weights.
+     *
+     * @param weights weights for splits, will be normalized if they don't sum to 1.
+     * @param seed Seed for sampling.
+     * @group dfops
+     * @since 1.4.0
+     */
+    randomSplit(...weights /*: Double* */) /*: Array[DataFrame]*/ {
+
+        throw new Error("Not implemented");
+
+        // for some reason, this crashes the jvm. yet constructing the array
+        // in the shell and passing it directly works. haven't dug into the
+        // node-java code yet.
+
+        var weightsArray = this.java.newArray("double", weights);
+
+        return this.jvm_obj.randomSplit(weightsArray);
+    }
+
+
+    /**
+     * Returns a new [[DataFrame]] by adding a column or replacing the existing column that has
+     * the same name.
+     * @group dfops
+     * @since 1.3.0
+     */
+    withColumn(colName /*: String */, col /*: Column */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.withColumn(colName, col));
+    }
+
+
+    /**
+     * Returns a new [[DataFrame]] with a column dropped.
+     * This is a no-op if schema doesn't contain column name.
+     * @group dfops
+     * @since 1.4.0
+     */
+    drop(col /*: String|Column */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.drop(col));
+    }
+
+
+    /**
+     * Returns a new [[DataFrame]] that contains only the unique rows from this [[DataFrame]].
+     * This is an alias for `distinct`.
+     * If column names are passed in, Rows are only compared in those columns.
+     *
+     * @group dfops
+     * @since 1.4.0
+     */
+    dropDuplicates(...colNames /*: String* */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.drop(...colNames));
+    }
+
+    /**
+     * Returns a new [[DataFrame]] that contains only the unique rows from this [[DataFrame]].
+     * This is an alias for `dropDuplicates`.
+     * @group dfops
+     * @since 1.3.0
+     */
+    distinct() /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.drop());
+    }
+
+    /**
+     * Computes statistics for numeric columns, including count, mean, stddev, min, and max.
+     * If no columns are given, this computes statistics for all numerical columns.
+     *
+     * This is meant for exploratory data analysis, as we make no guarantee about the
+     * backward compatibility of the schema of the resulting [[DataFrame]]. If you want to
+     * programmatically compute summary statistics, use the `agg` instead.
+     *
+     * {{{
+     *   df.describe("age", "height").show()
+     *
+     *   // output:
+     *   // summary age   height
+     *   // count   10.0  10.0
+     *   // mean    53.3  178.05
+     *   // stddev  11.6  15.7
+     *   // min     18.0  163.0
+     *   // max     92.0  192.0
+     * }}}
+     *
+     * @group action
+     * @since 1.3.1
+     */
+    /* @scala.annotation.varargs */
+    describe(...cols /*: String* */) /*: DataFrame */ {
+        return new DataFrame(this.jvm_obj.describe(...cols));
+
+    }
+
+    /**
+     * Returns the first `n` rows.
+     * @group action
+     * @since 1.3.0
+     *
+     * Running take requires moving data into the application's driver process, and doing so with
+     * a very large `n` can crash the driver process with OutOfMemoryError.
+     */
+    head(n=1 /*: Int */) /*: Array[Row]*/ {
+        return this.jvm_obj.head(n)
+            .map(row => new Row(row));
+    }
+
+    /**
+     * Returns an array that contains all of [[Row]]s in this [[DataFrame]].
+     *
+     * Running collect requires moving all the data into the application's driver process, and
+     * doing so on a very large dataset can crash the driver process with OutOfMemoryError.
+     *
+     * For Java API, use [[collectAsList]].
+     *
+     * @group action
+     * @since 1.3.0
+     */
+    collect() /*: Array[Row]*/ {
+        return this.jvm_obj.collect()
+            .map(row => new Row(row));
+    }
+
+    /**
+     * Returns the number of rows in the [[DataFrame]].
+     * @group action
+     * @since 1.3.0
+     */
+    count() /*: Long */ {
+        return this.jvm_obj.count();
+    }
+
+    /**
+     * Returns a partitioned [[DataFrame]].
+     *
+     * If partition expresions are provided, partitioned by the given partitioning expressions into
+     * `numPartitions`. The resulting DataFrame is hash partitioned. (This is the same operation as "DISTRIBUTE BY" in SQL (Hive QL).)
+     *
+     * @group dfops
+     * @since 1.3.0
+     */
+    repartition(numPartitions /*: Int */, ...partitionExprs /*: Column* */) /*: DataFrame */ {
+        if (partitionExprs.length===0) {
+            return new DataFrame(this.jvm_obj.repartition(numPartitions));
+        } else {
+            return new DataFrame(this.jvm_obj.repartition(numPartitions, partitionExprs /*: Column* */));
+        }
+    }
+
+
+
+    /**
+     * Registers this [[DataFrame]] as a temporary table using the given name.  The lifetime of this
+     * temporary table is tied to the [[SQLContext]] that was used to create this DataFrame.
+     *
+     * @group basic
+     * @since 1.3.0
+     */
+    registerTempTable(tableName /*: String */) /*: Unit */ {
+        this.jvm_obj.registerTempTable(tableName);
+    }
+
+    /**
+     * :: Experimental ::
+     * Interface for saving the content of the [[DataFrame]] out into external storage.
+     *
+     * @group output
+     * @since 1.4.0
+     */
+    write() /*: DataFrameWriter*/ {
+        // xxx
+    }
+}
+
+module.exports = DataFrame;

--- a/lib/DataFrameReader.js
+++ b/lib/DataFrameReader.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var DataFrame = require('./DataFrame.js');
+
+
+/**
+ * :: Experimental ::
+ * Interface used to load a [[DataFrame]] from external storage systems (e.g. file systems,
+ * key-value stores, etc). Use [[SQLContext.read]] to access this.
+ *
+ * @since 1.4.0
+ * @Experimental
+ */
+class DataFrameReader {
+
+    constructor (sqlContext /*: SQLContext*/, java) {
+        var jvm_DataFrameReader = java.import("org.apache.spark.sql.DataFrameReader");
+        this.sqlContext = sqlContext;
+        this.jvm_obj = new jvm_DataFrameReader(sqlContext.jvm_obj);
+        this.java = java;
+    }
+
+    /**
+     * Specifies the input data source format.
+     *
+     * @since 1.4.0
+     */
+    format(source /*: String */)/*: DataFrameReader */ {
+        this.jvm_obj.format(source);
+        return this;
+    }
+
+    /**
+     * Loads data from a data source and returns it as a [[DataFrame]].
+     *
+     * @param path - optional string for file-system backed data sources.
+     * @since 1.4.0
+     */
+    load(path=null /*: String */)/*: DataFrame */ {
+        if (path === null) {
+            return new DataFrame(this.jvm_obj.load(), this.java);
+        } else {
+            this.option("path", path);
+            return this.load();
+        }
+    }
+
+    /**
+     * Adds an input option for the underlying data source.
+     *
+     * @since 1.4.0
+     */
+    option(key /*: String */, value /*: String */) {
+        this.jvm_obj.option(key, value);
+        return this;
+    }
+
+    /**
+     * Loads a JSON file (one object per line) and returns the result as a [[DataFrame]].
+     *
+     * This function goes through the input once to determine the input schema. If you know the
+     * schema in advance, use the version that specifies the schema to avoid the extra scan.
+     *
+     * You can set the following JSON-specific options to deal with non-standard JSON files:
+     * <li>`primitivesAsString` (default `false`): infers all primitive values as a string type</li>
+     * <li>`allowComments` (default `false`): ignores Java/C++ style comment in JSON records</li>
+     * <li>`allowUnquotedFieldNames` (default `false`): allows unquoted JSON field names</li>
+     * <li>`allowSingleQuotes` (default `true`): allows single quotes in addition to double quotes
+     * </li>
+     * <li>`allowNumericLeadingZeros` (default `false`): allows leading zeros in numbers
+     * (e.g. 00012)</li>
+     *
+     * @param path input path
+     * @since 1.4.0
+     */
+    json(path /*: String */)/*: DataFrame */ {
+        return this.format("json").load(path);
+    }
+
+    /**
+     * Loads a text file and returns a [[DataFrame]] with a single string column named "text".
+     * Each line in the text file is a new row in the resulting DataFrame.
+     *
+     * @param path input path
+     * @since 1.6.0
+     */
+    text(path /*: String */)/*: DataFrame */ {
+        return this.format("text").load(path);
+    }
+}
+
+module.exports = DataFrameReader;

--- a/lib/GroupedData.js
+++ b/lib/GroupedData.js
@@ -1,0 +1,110 @@
+'use strict';
+
+
+class GroupedData {
+
+  constructor(jvm_obj/*: SQLContext*/) {
+    this.jvm_obj = jvm_obj;
+  }
+
+  /**
+   * Compute aggregates by specifying a series of aggregate columns. Note that this function by
+   * default retains the grouping columns in its output. To not retain grouping columns, set
+   * `spark.sql.retainGroupColumns` to false.
+   *
+   * The available aggregate methods are defined in [[org.apache.spark.sql.functions]].
+   *
+   * {{{
+   *   // Selects the age of the oldest employee and the aggregate expense for each department
+   *
+   *   // Scala:
+   *   import org.apache.spark.sql.functions._
+   *   df.groupBy("department").agg(max("age"), sum("expense"))
+   *
+   *   // Java:
+   *   import static org.apache.spark.sql.functions.*;
+   *   df.groupBy("department").agg(max("age"), sum("expense"));
+   * }}}
+   *
+   * Note that before Spark 1.4, the default behavior is to NOT retain grouping columns. To change
+   * to that behavior, set config variable `spark.sql.retainGroupColumns` to `false`.
+   * {{{
+   *   // Scala, 1.3.x:
+   *   df.groupBy("department").agg($"department", max("age"), sum("expense"))
+   *
+   *   // Java, 1.3.x:
+   *   df.groupBy("department").agg(col("department"), max("age"), sum("expense"));
+   * }}}
+   *
+   * @since 1.3.0
+   */
+  agg(...expr /*: Column* */) /*: DataFrame*/ {
+    return this.jvm_obj.agg(...expr);
+  }
+
+  /**
+   * Count the number of rows for each group.
+   * The resulting [[DataFrame]] will also contain the grouping columns.
+   *
+   * @since 1.3.0
+   */
+  count() /*: DataFrame */ {
+    return this.jvm_obj.count();
+  }
+
+  /**
+   * Compute the average value for each numeric columns for each group.
+   * The resulting [[DataFrame]] will also contain the grouping columns.
+   * When specified columns are given, only compute the average values for them.
+   *
+   * @since 1.3.0
+   */
+  avg(...colNames /*: String* */) /*: DataFrame*/ {
+    return this.jvm_obj.mean(...colNames);
+  }
+
+  /**
+   * Compute the max value for each numeric columns for each group.
+   * The resulting [[DataFrame]] will also contain the grouping columns.
+   * When specified columns are given, only compute the max values for them.
+   *
+   * @since 1.3.0
+   */
+  max(...colNames /*: String* */) /*: DataFrame*/ {
+    return this.jvm_obj.max(...colNames);
+  }
+
+  /**
+   * Compute the mean value for each numeric columns for each group. This is an alias for `avg`.
+   * The resulting [[DataFrame]] will also contain the grouping columns.
+   * When specified columns are given, only compute the mean values for them.
+   *
+   * @since 1.3.0
+   */
+  mean(...colNames /*: String* */) /*: DataFrame*/ {
+    return this.jvm_obj.mean(...colNames);
+  }
+
+  /**
+   * Compute the min value for each numeric column for each group.
+   * The resulting [[DataFrame]] will also contain the grouping columns.
+   * When specified columns are given, only compute the min values for them.
+   *
+   * @since 1.3.0
+   */
+  min(...colNames /*: String* */) /*: DataFrame*/ {
+    return this.jvm_obj.min(...colNames);
+  }
+
+  /**
+   * Compute the sum for each numeric columns for each group.
+   * The resulting [[DataFrame]] will also contain the grouping columns.
+   * When specified columns are given, only compute the sum for them.
+   *
+   * @since 1.3.0
+   */
+  sum(...colNames /*: String* */) /*: DataFrame*/ {
+    return this.jvm_obj.sum(...colNames);
+  }
+}
+module.exports = GroupedData;

--- a/lib/Row.js
+++ b/lib/Row.js
@@ -1,0 +1,57 @@
+'use strict';
+
+class Row {
+    constructor (jvm_obj) {
+        this.jvm_obj = jvm_obj;
+    }
+
+    /**
+     * Returns the value at position i. If the value is null, null is returned. The following
+     * is a mapping between Spark SQL types and return types:
+     *
+     * {{{
+     *   BooleanType -> java.lang.Boolean
+     *   ByteType -> java.lang.Byte
+     *   ShortType -> java.lang.Short
+     *   IntegerType -> java.lang.Integer
+     *   FloatType -> java.lang.Float
+     *   DoubleType -> java.lang.Double
+     *   StringType -> String
+     *   DecimalType -> java.math.BigDecimal
+     *
+     *   DateType -> java.sql.Date
+     *   TimestampType -> java.sql.Timestamp
+     *
+     *   BinaryType -> byte array
+     *   ArrayType -> scala.collection.Seq (use getList for java.util.List)
+     *   MapType -> scala.collection.Map (use getJavaMap for java.util.Map)
+     *   StructType -> org.apache.spark.sql.Row (or Product)
+     * }}}
+     */
+    get(i /*: Int*/ ) /*: Any*/ {
+        return this.jvm_obj.get(i);
+    }
+
+    /** Checks whether the value at position i is null. */
+    isNullAt(i /*: Int */) /*: Boolean*/{
+        return this.jvm_obj.isNullAt(i);
+    }
+
+    /**
+     * Returns the index of a given field name.
+     *
+     * @throws UnsupportedOperationException when schema is not defined.
+     * @throws IllegalArgumentException when fieldName do not exist.
+     */
+    fieldIndex(name /*: String*/) /*: Int */ {
+        return this.jvm_obj(name);
+    }
+
+    /** Returns true if there are any NULL values in this row. */
+    anyNull() /*: Boolean*/ {
+        return this.jvm_obj.anyNull();
+    }
+
+}
+
+module.exports = Row;

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,0 +1,1826 @@
+var F;
+
+/**
+ * Returns a [[Column]] based on the given column name.
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+function col(colName /*: String*/) /*: Column*/ {
+    return F.col(colName);
+}
+
+/**
+ * Returns a [[Column]] based on the given column name. Alias of [[col]].
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+function column(colName /*: String*/) /*: Column*/ {
+    return F.column(colName);
+}
+
+/**
+ * Creates a [[Column]] of literal value.
+ *
+ * The passed in object is returned directly if it is already a [[Column]].
+ * If the object is a Scala Symbol, it is converted into a [[Column]] also.
+ * Otherwise, a new [[Column]] is created to represent the literal value.
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+function lit(literal /*: Any* */) /*: Column*/ {
+    return F.lit(literal);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Sort functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns a sort expression based on ascending order of the column.
+ * {{{
+ *   // Sort by dept in ascending order, and then age in descending order.
+ *   df.sort(asc("dept"), desc("age"))
+ * }}}
+ *
+ * @group sort_funcs
+ * @since 1.3.0
+ */
+function asc(columnName /*: String*/) /*: Column*/ {
+    return F.asc(columnName);
+}
+
+/**
+ * Returns a sort expression based on the descending order of the column.
+ * {{{
+ *   // Sort by dept in ascending order, and then age in descending order.
+ *   df.sort(asc("dept"), desc("age"))
+ * }}}
+ *
+ * @group sort_funcs
+ * @since 1.3.0
+ */
+function desc(columnName /*: String*/) /*: Column*/ {
+    return F.desc(columnName);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Aggregate functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+
+/**
+ * Aggregate function: returns the approximate number of distinct items in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function approxCountDistinct(e /*: Column*/, rsd=null /*: Double*/) /*: Column*/ {
+    if (rsd === null) {
+        return F.approxCountDistinct(e, rsd);
+    } else {
+        return F.approxCountDistinct(e);
+    }
+}
+
+/**
+ * Aggregate function: returns a list of objects with duplicates.
+ *
+ * For now this is an alias for the collect_list Hive UDAF.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function collect_list(e /*: Column*/) /*: Column*/ {
+    return F.collect_list(e);
+}
+
+/**
+ * Aggregate function: returns a set of objects with duplicate elements eliminated.
+ *
+ * For now this is an alias for the collect_set Hive UDAF.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function collect_set(e /*: Column*/) /*: Column*/ {
+    return F.collect_set(e);
+}
+
+/**
+ * Aggregate function: returns the Pearson Correlation Coefficient for two columns.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function corr(column1 /*: Column | String*/, column2 /*: Column | String*/) /*: Column*/ {
+    return F.corr(column1, column2);
+}
+
+/**
+ * Aggregate function: returns the number of items in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function count(col /*: String | Column */) /*: Column*/ {
+    return F.count();
+}
+
+/**
+ * Aggregate function: returns the number of distinct items in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+/* @scala.annotation.varargs */
+function countDistinct(col /*: Column | String */, ...cols /*: Column* | String* */) /*: Column*/ {
+    if (cols.length === 0) {
+        return F.countDistinct(col);
+    } else {
+        return F.countDistinct(col, cols);
+    }
+}
+
+/**
+ * Aggregate function: returns the first value in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function first(col /*: String | Column */) /*: Column*/ {
+    return F.first(col);
+}
+
+/**
+ * Aggregate function: returns the kurtosis of the values in a group.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function kurtosis(e /*: Column*/) /*: Column*/ {
+    return F.kurtosis(e);
+}
+
+/**
+ * Aggregate function: returns the last value in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function last(col /*: String | Column */) /*: Column*/ {
+    return F.last(col);
+}
+
+/**
+ * Aggregate function: returns the maximum value of the expression in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function max(col /*: Column | String */) /*: Column*/ {
+    return F.max(col);
+}
+
+/**
+ * Aggregate function: returns the average of the values in a group.
+ * Alias for avg.
+ *
+ * @group agg_funcs
+ * @since 1.4.0
+ */
+function mean(col /*: Column | String */) /*: Column*/ {
+    return F.mean(col);
+}
+
+/**
+ * Aggregate function: returns the minimum value of the expression in a group.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function min(col /*: Column | String */) /*: Column*/ {
+    return F.min(col);
+}
+
+/**
+ * Aggregate function: returns the skewness of the values in a group.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function skewness(e /*: Column*/) /*: Column*/ {
+    return F.skewness(e);
+}
+
+/**
+ * Aggregate function: alias for [[stddev_samp]].
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function stddev(e /*: Column*/) /*: Column*/ {
+    return F.stddev(col);
+}
+
+/**
+ * Aggregate function: returns the sample standard deviation of
+ * the expression in a group.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function stddev_samp(e /*: Column*/) /*: Column*/ {
+    return F.stddev(col);
+}
+
+/**
+ * Aggregate function: returns the population standard deviation of
+ * the expression in a group.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function stddev_pop(e /*: Column*/) /*: Column*/ {
+    return F.stddev(col);
+}
+
+/**
+ * Aggregate function: returns the sum of all values in the expression.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function sum(col /*: Column | String */) /*: Column*/ {
+    return F.sum(col);
+}
+
+/**
+ * Aggregate function: returns the sum of distinct values in the expression.
+ *
+ * @group agg_funcs
+ * @since 1.3.0
+ */
+function sumDistinct(col /*: Column | String */) /*: Column*/ {
+    return F.sumDistinct(col);
+}
+
+/**
+ * Aggregate function: alias for [[var_samp]].
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function variance(e /*: Column*/) /*: Column*/ {
+    return F.variance(col);
+}
+
+/**
+ * Aggregate function: returns the unbiased variance of the values in a group.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function var_samp(e /*: Column*/) /*: Column*/ {
+    return F.var(col);
+}
+
+/**
+ * Aggregate function: returns the population variance of the values in a group.
+ *
+ * @group agg_funcs
+ * @since 1.6.0
+ */
+function var_pop(e /*: Column*/) /*: Column*/ {
+    return F.var(col);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Window functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Window function: returns the cumulative distribution of values within a window partition,
+ * i.e. the fraction of rows that are below the current row.
+ *
+ * {{{
+ *   N { }
+ *   cumeDist(x) { }
+ * }}}
+ *
+ *
+ * This is equivalent to the CUME_DIST function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function cumeDist() /*: Column*/ {
+    return F.cumeDist();
+}
+
+/**
+ * Window function: returns the rank of rows within a window partition, without any gaps.
+ *
+ * The difference between rank and denseRank is that denseRank leaves no gaps in ranking
+ * sequence when there are ties. That is, if you were ranking a competition using denseRank
+ * and had three people tie for second place, you would say that all three were in second
+ * place and that the next person came in third.
+ *
+ * This is equivalent to the DENSE_RANK function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function denseRank() /*: Column*/ {
+    return F.denseRank();
+}
+
+/**
+ * Window function: returns the value that is `offset` rows before the current
+ * row, and `null` (or optional `defaultValue`, if provided) if there is less
+ * than `offset` rows before the current row. For example, an `offset` of one
+ * will return the previous row at any given point in the window partition.
+ *
+ * This is equivalent to the LAG function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function lag(col /*: Column | String */, offset=null /*: Int*/, defaultValue=null /*: Any*/) /*: Column*/ {
+    if (offset === null) {
+        return F.lag(col);
+    } else if (defaultValue == null) {
+        return F.lag(col, offset);
+    } else {
+        return F.lag(col, offset, defaultValue);
+    }
+}
+
+
+/**
+ * Window function: returns the value that is `offset` rows after the current row, and
+ * null (or optional `defaultValue`, if provided) if there is less than `offset` rows after the current row. For example,
+ * an `offset` of one will return the next row at any given point in the window partition.
+ *
+ * This is equivalent to the LEAD function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function lead(col /*: String*/, offset /*: Int*/, defaultValue /*: Any*/) /*: Column*/ {
+    if (offset === null) {
+        return F.lead(col);
+    } else if (defaultValue == null) {
+        return F.lead(col, offset);
+    } else {
+        return F.lead(col, offset, defaultValue);
+    }
+}
+
+
+/**
+ * Window function: returns the ntile group id (from 1 to `n` inclusive) in an ordered window
+ * partition. Fow example, if `n` is 4, the first quarter of the rows will get value 1, the second
+ * quarter will get 2, the third quarter will get 3, and the last quarter will get 4.
+ *
+ * This is equivalent to the NTILE function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function ntile(n /*: Int*/) /*: Column*/ {
+    return F.ntile(n);
+}
+
+/**
+ * Window function: returns the relative rank (i.e. percentile) of rows within a window partition.
+ *
+ * This is computed by :
+ * {{{
+ *   (rank of row in its partition - 1) / (number of rows in the partition - 1)
+ * }}}
+ *
+ * This is equivalent to the PERCENT_RANK function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function percentRank() /*: Column*/ {
+    return F.percentRank();
+}
+
+/**
+ * Window function: returns the rank of rows within a window partition.
+ *
+ * The difference between rank and denseRank is that denseRank leaves no gaps in ranking
+ * sequence when there are ties. That is, if you were ranking a competition using denseRank
+ * and had three people tie for second place, you would say that all three were in second
+ * place and that the next person came in third.
+ *
+ * This is equivalent to the RANK function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function rank() /*: Column*/ {
+    return F.rank();
+}
+
+/**
+ * Window function: returns a sequential number starting at 1 within a window partition.
+ *
+ * This is equivalent to the ROW_NUMBER function in SQL.
+ *
+ * @group window_funcs
+ * @since 1.4.0
+ */
+function rowNumber() /*: Column*/ {
+    return F.rowNumber();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Non-aggregate functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Computes the absolute value.
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+function abs(e /*: Column*/) /*: Column*/ {
+    return F.abs(col);
+}
+
+/**
+ * Creates a new array column. The input columns must all have the same data type.
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+// xxx this function currently can't take strings, because the corresponding Scala
+// function is lacking a @scala.annotation.varargs annotation
+/* @scala.annotation.varargs */
+function array(...cols /*: Column* */) /*: Column*/ {
+    return F.array(...cols);
+}
+
+/**
+ * Marks a DataFrame as small enough for use in broadcast joins.
+ *
+ * The following example marks the right DataFrame for broadcast hash join using `joinKey`.
+ * {{{
+ *   // left and right are DataFrames
+ *   left.join(broadcast(right), "joinKey")
+ * }}}
+ *
+ * @group normal_funcs
+ * @since 1.5.0
+ */
+function broadcast(df /*: DataFrame*/) /*: DataFrame*/ {
+    return F.broadcast(df);
+}
+
+/**
+ * Returns the first column that is not null, or null if all inputs are null.
+ *
+ * For example, `coalesce(a, b, c)` will return a if a is not null,
+ * or b if a is null and b is not null, or c if both a and b are null but c is not null.
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+/* @scala.annotation.varargs */
+function coalesce(e /*: Column* */) /*: Column*/ {
+    return F.coalesce(e);
+}
+
+/**
+ * Creates a string column for the file name of the current Spark task.
+ *
+ * @group normal_funcs
+ */
+function inputFileName() /*: Column*/ {
+    return F.inputFileName();
+}
+
+/**
+ * Return true iff the column is NaN.
+ *
+ * @group normal_funcs
+ * @since 1.5.0
+ */
+function isNaN(e /*: Column*/) /*: Column*/ {
+    return F.isNaN(col);
+}
+
+/**
+ * A column expression that generates monotonically increasing 64-bit integers.
+ *
+ * The generated ID is guaranteed to be monotonically increasing and unique, but not consecutive.
+ * The current implementation puts the partition ID in the upper 31 bits, and the record number
+ * within each partition in the lower 33 bits. The assumption is that the data frame has
+ * less than 1 billion partitions, and each partition has less than 8 billion records.
+ *
+ * As an example, consider a [[DataFrame]] with two partitions, each with 3 records.
+ * This expression would return the following IDs /*:
+ * 0, 1, 2, 8589934592 (1L << 33), 8589934593, 8589934594.
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+function monotonicallyIncreasingId() /*: Column*/ {
+    return F.monotonicallyIncreasingId();
+}
+
+/**
+ * Returns col1 if it is not NaN, or col2 if col1 is NaN.
+ *
+ * Both inputs should be floating point columns (DoubleType or FloatType).
+ *
+ * @group normal_funcs
+ * @since 1.5.0
+ */
+function nanvl(col1 /*: Column*/, col2 /*: Column*/) /*: Column*/ {
+    return F.nanvl(col1, col2);
+}
+
+/**
+ * Unary minus, i.e. negate the expression.
+ * {{{
+ *   // Select the amount column and negates all values.
+ *   // Scala /*:
+ *   df.select( -df("amount") )
+ *
+ *   // Java /*:
+ *   df.select( negate(df.col("amount")) );
+ * }}}
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+function negate(e /*: Column*/) /*: Column*/ {
+    return F.negate(col);
+}
+
+/**
+ * Inversion of boolean expression, i.e. NOT.
+ * {{{
+ *   // Scala: select rows that are not active (isActive === false)
+ *   df.filter( !df("isActive") )
+ *
+ *   // Java:
+ *   df.filter( not(df.col("isActive")) );
+ * }}}
+ *
+ * @group normal_funcs
+ * @since 1.3.0
+ */
+function not(col /*: Column*/) /*: Column*/ {
+    return F.not(col);
+}
+
+/**
+ * Generate a random column with i.i.d. samples from U[0.0, 1.0].
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+function rand(seed=null /*: Long*/) /*: Column*/ {
+    if (seed === null) {
+        return F.rand();
+    } else {
+        return F.rand(seed);
+    }
+}
+
+/**
+ * Generate a column with i.i.d. samples from the standard normal distribution.
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+function randn(seed /*: Long*/) /*: Column*/ {
+    if (seed === null) {
+        return F.randn();
+    } else {
+        return F.randn(seed);
+    }
+}
+
+/**
+ * Partition ID of the Spark task.
+ *
+ * Note that this is indeterministic because it depends on data partitioning and task scheduling.
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+function sparkPartitionId() /*: Column*/ {
+    return F.sparkPartitionId();
+}
+
+/**
+ * Computes the square root of the specified float value.
+ *
+ * @group math_funcs
+ * @since 1.3.0
+ */
+function sqrt(col /*: Column | String*/) /*: Column*/ {
+    return F.sqrt(col);
+}
+
+/**
+ * Creates a new struct column.
+ * If the input column is a column in a [[DataFrame]], or a derived column expression
+ * that is named (i.e. aliased), its name would be remained as the StructField's name,
+ * otherwise, the newly generated StructField's name would be auto generated as col${index + 1},
+ * i.e. col1, col2, col3, ...
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+// xxx this function currently can't take strings, because the corresponding Scala
+// function is lacking a @scala.annotation.varargs annotation
+/* @scala.annotation.varargs */
+function struct(...cols /*: Column* */) /*: Column*/ {
+    return F.struct(...cols);
+}
+
+
+/**
+ * Evaluates a list of conditions and returns one of multiple possible result expressions.
+ * If otherwise is not defined at the end, null is returned for unmatched conditions.
+ *
+ * {{{
+ *   // Example: encoding gender string column into integer.
+ *
+ *   // Scala:
+ *   people.select(when(people("gender") === "male", 0)
+ *     .when(people("gender") === "female", 1)
+ *     .otherwise(2))
+ *
+ *   // Java:
+ *   people.select(when(col("gender").equalTo("male"), 0)
+ *     .when(col("gender").equalTo("female"), 1)
+ *     .otherwise(2))
+ * }}}
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+function when(condition /*: Column*/, value /*: Any*/) /*: Column*/ {
+    return F.when(condition, value);
+}
+
+/**
+ * Computes bitwise NOT.
+ *
+ * @group normal_funcs
+ * @since 1.4.0
+ */
+function bitwiseNOT(e /*: Column*/) /*: Column*/ {
+    return F.bitwiseNOT(col);
+}
+
+/**
+ * Parses the expression string into the column that it represents, similar to
+ * DataFrame.selectExpr
+ * {{{
+ *   // get the number of words of each length
+ *   df.groupBy(expr("length(word)")).count()
+ * }}}
+ *
+ * @group normal_funcs
+ */
+function expr(expr /*: String*/) /*: Column*/ {
+    return F.expr(expr);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Math Functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Computes the cosine inverse of the given value; the returned angle is in the range
+ * 0.0 through pi.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function acos(col /*: Column | String */) /*: Column*/ {
+    return F.acos(col);
+}
+
+/**
+ * Computes the sine inverse of the given value; the returned angle is in the range
+ * -pi/2 through pi/2.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function asin(col /*: Column | String */) /*: Column*/ {
+    return F.asin(col);
+}
+
+/**
+ * Computes the tangent inverse of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function atan(col /*: Column | String */) /*: Column*/ {
+    return F.atan(col);
+}
+
+/**
+ * Returns the angle theta from the conversion of rectangular coordinates (x, y) to
+ * polar coordinates (r, theta).
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function atan2(l /*: Column|String|Double */, r /*: Column|String|Double */) /*: Column*/ {
+    return F.atan2(l, r);
+}
+
+/**
+ * An expression that returns the string representation of the binary value of the given long
+ * column. For example, bin("12") returns "1100".
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function bin(col /*: Column | String */) /*: Column*/ {
+    return F.bin(col);
+}
+
+/**
+ * Computes the cube-root of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function cbrt(col /*: Column | String */) /*: Column*/ {
+    return F.cbrt(col);
+}
+
+/**
+ * Computes the ceiling of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function ceil(col /*: Column | String */) /*: Column*/ {
+    return F.ceil(col);
+}
+
+/**
+ * Convert a number in a string column from one base to another.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function conv(num /*: Column*/, fromBase /*: Int*/, toBase /*: Int*/) /*: Column*/ {
+    return F.conv(num /*: Column*/, fromBase, toBase);
+}
+
+/**
+ * Computes the cosine of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function cos(col /*: Column | String */) /*: Column*/ {
+    return F.cos(col);
+}
+
+/**
+ * Computes the hyperbolic cosine of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function cosh(col /*: Column | String */) /*: Column*/ {
+    return F.cosh(col);
+}
+
+/**
+ * Computes the exponential of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function exp(col /*: Column | String */) /*: Column*/ {
+    return F.exp(col);
+}
+
+/**
+ * Computes the exponential of the given value minus one.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function expm1(col /*: Column | String */) /*: Column*/ {
+    return F.expm1(col);
+}
+
+/**
+ * Computes the factorial of the given value.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function factorial(e /*: Column*/) /*: Column*/ {
+    return F.factorial(col);
+}
+
+/**
+ * Computes the floor of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function floor(col /*: Column | String */) /*: Column*/ {
+    return F.floor(col);
+}
+
+/**
+ * Returns the greatest value of the list of values, skipping null values.
+ * This function takes at least 2 parameters. It will return null iff all parameters are null.
+ *
+ * @group normal_funcs
+ * @since 1.5.0
+ */
+/* @scala.annotation.varargs */
+function greatest(...cols /*: Column*|String* */) /*: Column*/ {
+    return F.greatest(...cols);
+}
+
+/**
+ * Computes hex value of the given column.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function hex(column /*: Column*/) /*: Column*/ {
+    return F.hex(column);
+}
+
+/**
+ * Inverse of hex. Interprets each pair of characters as a hexadecimal number
+ * and converts to the byte representation of number.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function unhex(column /*: Column*/) /*: Column*/ {
+    return F.unhex(column);
+}
+
+/**
+ * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function hypot(l /*: Column|String|Double */, r /*: Column|String|Double*/) /*: Column*/ {
+    return F.hypot(l, r);
+}
+
+/**
+ * Returns the least value of the list of values, skipping null values.
+ * This function takes at least 2 parameters. It will return null iff all parameters are null.
+ *
+ * @group normal_funcs
+ * @since 1.5.0
+ */
+/* @scala.annotation.varargs */
+function least(...cols /*: (Column*|String*) */) /*: Column*/ {
+    return F.least(...cols);
+}
+
+/**
+ * Computes the natural logarithm of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function log(col /*: Column | String */, base=null /*: Double*/) /*: Column*/ {
+    if (base === null) {
+        return F.log(col);
+    } else {
+        return F.log(base, col)
+    }
+}
+
+/**
+ * Returns the first argument-base logarithm of the second argument.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function log(base /*: Double*/, columnName /*: String*/) /*: Column*/ {
+    return F.log(base, columnName);
+}
+
+/**
+ * Computes the logarithm of the given value in base 10.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function log10(col /*: Column | String */) /*: Column*/ {
+    return F.log10(col);
+}
+
+/**
+ * Computes the natural logarithm of the given value plus one.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function log1p(col /*: Column | String */) /*: Column*/ {
+    return F.log1p(col);
+}
+
+/**
+ * Computes the logarithm of the given column in base 2.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function log2(col /*: Column | String */) /*: Column*/ {
+    return F.log2(expr);
+}
+
+/**
+ * Returns the value of the first argument raised to the power of the second argument.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function pow(l /*: Column|Double|String*/, r /*: Column|Double|String*/) /*: Column*/ {
+    return F.pow(l, r);
+}
+
+
+/**
+ * Returns the positive value of dividend mod divisor.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function pmod(dividend /*: Column*/, divisor /*: Column*/) /*: Column*/ {
+    return F.pmod(dividend, divisor);
+}
+
+/**
+ * Returns the double value that is closest in value to the argument and
+ * is equal to a mathematical integer.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function rint(col /*: Column | String */) /*: Column*/ {
+    return F.rint(col);
+}
+
+/**
+ * Returns the value of the column `e` roundd to 0 decimal places.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function round(e /*: Column*/, scale=0 /*: Int*/) /*: Column*/ {
+    return F.round(col, scale);
+}
+
+/**
+ * Shift the the given value numBits left. If the given value is a long value, this function
+ * will return a long value else it will return an integer value.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function shiftLeft(e /*: Column*/, numBits /*: Int*/) /*: Column*/ {
+    return F.shiftLeft(col, numBits);
+}
+
+/**
+ * Shift the the given value numBits right. If the given value is a long value, it will return
+ * a long value else it will return an integer value.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function shiftRight(e /*: Column*/, numBits /*: Int*/) /*: Column*/ {
+    return F.shiftRight(col, numBits);
+}
+
+/**
+ * Unsigned shift the the given value numBits right. If the given value is a long value,
+ * it will return a long value else it will return an integer value.
+ *
+ * @group math_funcs
+ * @since 1.5.0
+ */
+function shiftRightUnsigned(e /*: Column*/, numBits /*: Int*/) /*: Column*/ {
+    return F.shiftRightUnsigned(col, numBits);
+}
+
+/**
+ * Computes the signum of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function signum(col /*: Column | String */) /*: Column*/ {
+    return F.signum(col);
+}
+
+/**
+ * Computes the sine of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function sin(col /*: Column | String */) /*: Column*/ {
+    return F.sin(col);
+}
+
+/**
+ * Computes the hyperbolic sine of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function sinh(col /*: Column | String */) /*: Column*/ {
+    return F.sinh(col);
+}
+
+/**
+ * Computes the tangent of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function tan(col /*: Column | String */) /*: Column*/ {
+    return F.tan(col);
+}
+
+/**
+ * Computes the hyperbolic tangent of the given value.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function tanh(col /*: Column | String */) /*: Column*/ {
+    return F.tanh(col);
+}
+
+/**
+ * Converts an angle measured in radians to an approximately equivalent angle measured in degrees.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function toDegrees(col /*: Column | String */) /*: Column*/ {
+    return F.toDegrees(col);
+}
+
+/**
+ * Converts an angle measured in degrees to an approximately equivalent angle measured in radians.
+ *
+ * @group math_funcs
+ * @since 1.4.0
+ */
+function toRadians(col /*: Column | String */) /*: Column*/ {
+    return F.toRadians(col);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Misc functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Calculates the MD5 digest of a binary column and returns the value
+ * as a 32 character hex string.
+ *
+ * @group misc_funcs
+ * @since 1.5.0
+ */
+function md5(e /*: Column*/) /*: Column*/ {
+    return F.md5(col);
+}
+
+/**
+ * Calculates the SHA-1 digest of a binary column and returns the value
+ * as a 40 character hex string.
+ *
+ * @group misc_funcs
+ * @since 1.5.0
+ */
+function sha1(e /*: Column*/) /*: Column*/ {
+    return F.sha1(col);
+}
+
+/**
+ * Calculates the SHA-2 family of hash functions of a binary column and
+ * returns the value as a hex string.
+ *
+ * @param e column to compute SHA-2 on.
+ * @param numBits one of 224, 256, 384, or 512.
+ *
+ * @group misc_funcs
+ * @since 1.5.0
+ */
+function sha2(e /*: Column*/, numBits /*: Int*/) /*: Column*/ {
+    return F.sha2(col, numBits);
+}
+
+/**
+ * Calculates the cyclic redundancy check value  (CRC32) of a binary column and
+ * returns the value as a bigint.
+ *
+ * @group misc_funcs
+ * @since 1.5.0
+ */
+function crc32(e /*: Column*/) /*: Column*/ {
+    return F.crc32(col);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// String functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Computes the numeric value of the first character of the string column, and returns the
+ * result as a int column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function ascii(e /*: Column*/) /*: Column*/ {
+    return F.ascii(col);
+}
+
+/**
+ * Computes the BASE64 encoding of a binary column and returns it as a string column.
+ * This is the reverse of unbase64.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function base64(e /*: Column*/) /*: Column*/ {
+    return F.base64(col);
+}
+
+/**
+ * Concatenates multiple input string columns together into a single string column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+/* @scala.annotation.varargs */
+function concat(exprs /*: Column* */) /*: Column*/ {
+    return F.concat(exprs);
+}
+
+/**
+ * Concatenates multiple input string columns together into a single string column,
+ * using the given separator.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+/* @scala.annotation.varargs */
+function concat_ws(sep /*: String*/, exprs /*: Column* */) /*: Column*/ {
+    return F.concat_ws(sep, exprs);
+}
+
+/**
+ * Computes the first argument into a string from a binary using the provided character set
+ * (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
+ * If either argument is null, the result will also be null.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function decode(value /*: Column*/, charset /*: String*/) /*: Column*/ {
+    return F.decode(valucol, charset);
+}
+
+/**
+ * Computes the first argument into a binary from a string using the provided character set
+ * (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
+ * If either argument is null, the result will also be null.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function encode(value /*: Column*/, charset /*: String*/) /*: Column*/ {
+    return F.encode(valucol, charset);
+}
+
+/**
+ * Formats numeric column x to a format like '#,###,###.##', rounded to d decimal places,
+ * and returns the result as a string column.
+ *
+ * If d is 0, the result has no decimal point or fractional part.
+ * If d < 0, the result will be null.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function format_number(x /*: Column*/, d /*: Int*/) /*: Column*/ {
+    return F.format_number(x, d);
+}
+
+/**
+ * Formats the arguments in printf-style and returns the result as a string column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+/* @scala.annotation.varargs */
+function format_string(format /*: String*/, args /*: Column* */) /*: Column*/ {
+    return F.format_string(format, args);
+}
+
+/**
+ * Returns a new string column by converting the first letter of each word to uppercase.
+ * Words are delimited by whitespace.
+ *
+ * For example, "hello world" will become "Hello World".
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function initcap(e /*: Column*/) /*: Column*/ {
+    return F.initcap(col);
+}
+
+/**
+ * Locate the position of the first occurrence of substr column in the given string.
+ * Returns null if either of the arguments are null.
+ *
+ * NOTE: The position is not zero based, but 1 based index, returns 0 if substr
+ * could not be found in str.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function instr(str /*: Column*/, substring /*: String*/) /*: Column*/ {
+    return F.instr(str, substring);
+}
+
+/**
+ * Computes the length of a given string or binary column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function length(e /*: Column*/) /*: Column*/ {
+    return F.length(col);
+}
+
+/**
+ * Converts a string column to lower case.
+ *
+ * @group string_funcs
+ * @since 1.3.0
+ */
+function lower(e /*: Column*/) /*: Column*/ {
+    return F.lower(col);
+}
+
+/**
+ * Computes the Levenshtein distance of the two given string columns.
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function levenshtein(l /*: Column*/, r /*: Column*/) /*: Column*/ {
+    return F.levenshtein(l, r);
+}
+
+/**
+ * Locate the position of the first occurrence of substr.
+ * NOTE: The position is not zero based, but 1 based index, returns 0 if substr
+ * could not be found in str.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function locate(substr /*: String*/, str /*: Column*/) /*: Column*/ {
+    return F.locate(substr, str);
+}
+
+/**
+ * Locate the position of the first occurrence of substr in a string column, after position pos.
+ *
+ * NOTE: The position is not zero based, but 1 based index. returns 0 if substr
+ * could not be found in str.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function locate(substr /*: String*/, str /*: Column*/, pos /*: Int*/) /*: Column*/ {
+    return F.locate(substr /*: String*/, str, pos);
+}
+
+/**
+ * Left-pad the string column with
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function lpad(str /*: Column*/, len /*: Int*/, pad /*: String*/) /*: Column*/ {
+    return F.lpad(str /*: Column*/, len, pad);
+}
+
+/**
+ * Trim the spaces from left end for the specified string value.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function ltrim(e /*: Column*/) /*: Column*/ {
+    return F.ltrim(col);
+}
+
+/**
+ * Extract a specific(idx) group identified by a java regex, from the specified string column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function regexp_extract(e /*: Column*/, exp /*: String*/, groupIdx /*: Int*/) /*: Column*/ {
+    return F.regexp_extract(col, exp, groupIdx);
+}
+
+/**
+ * Replace all substrings of the specified string value that match regexp with rep.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function regexp_replace(e /*: Column*/, pattern /*: String*/, replacement /*: String*/) /*: Column*/ {
+    return F.regexp_replace(col, pattern, replacement);
+}
+
+/**
+ * Decodes a BASE64 encoded string column and returns it as a binary column.
+ * This is the reverse of base64.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function unbase64(e /*: Column*/) /*: Column*/ {
+    return F.unbase64(col);
+}
+
+/**
+ * Right-padded with pad to a length of len.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function rpad(str /*: Column*/, len /*: Int*/, pad /*: String*/) /*: Column*/ {
+    return F.rpad(str /*: Column*/, len, pad);
+}
+
+/**
+ * Repeats a string column n times, and returns it as a new string column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function repeat(str /*: Column*/, n /*: Int*/) /*: Column*/ {
+    return F.repeat(str, n);
+}
+
+/**
+ * Reverses the string column and returns it as a new string column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function reverse(str /*: Column*/) /*: Column*/ {
+    return F.reverse(str);
+}
+
+/**
+ * Trim the spaces from right end for the specified string value.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function rtrim(e /*: Column*/) /*: Column*/ {
+    return F.rtrim(col);
+}
+
+/**
+ * * Return the soundex code for the specified expression.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function soundex(e /*: Column*/) /*: Column*/ {
+    return F.soundex(col);
+}
+
+/**
+ * Splits str around pattern (pattern is a regular expression).
+ * NOTE: pattern is a string represent the regular expression.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function split(str /*: Column*/, pattern /*: String*/) /*: Column*/ {
+    return F.split(str, pattern);
+}
+
+/**
+ * Substring starts at `pos` and is of length `len` when str is String type or
+ * returns the slice of byte array that starts at `pos` in byte and is of length `len`
+ * when str is Binary type
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function substring(str /*: Column*/, pos /*: Int*/, len /*: Int*/) /*: Column*/ {
+    return F.substring(str /*: Column*/, pos, len);
+}
+
+/**
+ * Returns the substring from string str before count occurrences of the delimiter delim.
+ * If count is positive, everything the left of the final delimiter (counting from left) is
+ * returned. If count is negative, every to the right of the final delimiter (counting from the
+ * right) is returned. substring_index performs a case-sensitive match when searching for delim.
+ *
+ * @group string_funcs
+ */
+function substring_index(str /*: Column*/, delim /*: String*/, count /*: Int*/) /*: Column*/ {
+    return F.substring_index(str /*: Column*/, delim, count);
+}
+
+/**
+ * Translate any character in the src by a character in replaceString.
+ * The characters in replaceString is corresponding to the characters in matchingString.
+ * The translate will happen when any character in the string matching with the character
+ * in the matchingString.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function translate(src /*: Column*/, matchingString /*: String*/, replaceString /*: String*/) /*: Column*/ {
+    return F.translate(src /*: Column*/, matchingString, replaceString);
+}
+
+/**
+ * Trim the spaces from both ends for the specified string column.
+ *
+ * @group string_funcs
+ * @since 1.5.0
+ */
+function trim(e /*: Column*/) /*: Column*/ {
+    return F.trim(col);
+}
+
+/**
+ * Converts a string column to upper case.
+ *
+ * @group string_funcs
+ * @since 1.3.0
+ */
+function upper(e /*: Column*/) /*: Column*/ {
+    return F.upper(col);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// DateTime functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns the date that is numMonths after startDate.
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function add_months(startDate /*: Column*/, numMonths /*: Int*/) /*: Column*/ {
+    return F.add_months(startDatcol, numMonths);
+}
+
+/**
+ * Returns the current date as a date column.
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function current_date() /*: Column*/ {
+    return F.current_date();
+}
+
+/**
+ * Returns the current timestamp as a timestamp column.
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function current_timestamp() /*: Column*/ {
+    return F.current_timestamp();
+}
+
+/**
+ * Converts a date/timestamp/string to a value of string in the format specified by the date
+ * format given by the second argument.
+ *
+ * A pattern could be for instance `dd.MM.yyyy` and could return a string like '18.03.1993'. All
+ * pattern letters of [[java.text.SimpleDateFormat]] can be used.
+ *
+ * NOTE: Use when ever possible specialized functions like [[year]]. These benefit from a
+ * specialized implementation.
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function date_format(dateExpr /*: Column*/, format /*: String*/) /*: Column*/ {
+    return F.date_format(dateExpr, format);
+}
+
+/**
+ * Returns the date that is `days` days after `start`
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function date_add(start /*: Column*/, days /*: Int*/) /*: Column*/ {
+    return F.date_add(start, days);
+}
+
+/**
+ * Returns the date that is `days` days before `start`
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function date_sub(start /*: Column*/, days /*: Int*/) /*: Column*/ {
+    return F.date_sub(start, days);
+}
+
+/**
+ * Returns the number of days from `start` to `end`.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function datediff(end /*: Column*/, start /*: Column*/) /*: Column*/ {
+    return F.datediff(end, start);
+}
+
+/**
+ * Extracts the year as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function year(e /*: Column*/) /*: Column*/ {
+    return F.year(col);
+}
+
+/**
+ * Extracts the quarter as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function quarter(e /*: Column*/) /*: Column*/ {
+    return F.quarter(col);
+}
+
+/**
+ * Extracts the month as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function month(e /*: Column*/) /*: Column*/ {
+    return F.month(col);
+}
+
+/**
+ * Extracts the day of the month as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function dayofmonth(e /*: Column*/) /*: Column*/ {
+    return F.dayofmonth(col);
+}
+
+/**
+ * Extracts the day of the year as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function dayofyear(e /*: Column*/) /*: Column*/ {
+    return F.dayofyear(col);
+}
+
+/**
+ * Extracts the hours as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function hour(e /*: Column*/) /*: Column*/ {
+    return F.hour(col);
+}
+
+/**
+ * Given a date column, returns the last day of the month which the given date belongs to.
+ * For example, input "2015-07-27" returns "2015-07-31" since July 31 is the last day of the
+ * month in July 2015.
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function last_day(e /*: Column*/) /*: Column*/ {
+    return F.last_day(col);
+}
+
+/**
+ * Extracts the minutes as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function minute(e /*: Column*/) /*: Column*/ {
+    return F.minute(col);
+}
+
+/*
+ * Returns number of months between dates `date1` and `date2`.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function months_between(date1 /*: Column*/, date2 /*: Column*/) /*: Column*/ {
+    return F.months_between(date1, date2);
+}
+
+/**
+ * Given a date column, returns the first date which is later than the value of the date column
+ * that is on the specified day of the week.
+ *
+ * For example, `next_day('2015-07-27', "Sunday")` returns 2015-08-02 because that is the first
+ * Sunday after 2015-07-27.
+ *
+ * Day of the week parameter is case insensitive, and accepts:
+ * "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun".
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function next_day(date /*: Column*/, dayOfWeek /*: String*/) /*: Column*/ {
+    return F.next_day(datcol, dayOfWeek);
+}
+
+/**
+ * Extracts the seconds as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function second(e /*: Column*/) /*: Column*/ {
+    return F.second(col);
+}
+
+/**
+ * Extracts the week number as an integer from a given date/timestamp/string.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function weekofyear(e /*: Column*/) /*: Column*/ {
+    return F.weekofyear(col);
+}
+
+/**
+ * Converts the number of seconds from unix epoch (1970-01-01 00:00:00 UTC) to a string
+ * representing the timestamp of that moment in the current system time zone in the given
+ * format (defaults to "yyyy-MM-dd HH:mm:ss").
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function from_unixtime(ut /*: Column*/, f=null /*: String*/) /*: Column*/ {
+    if (f === null) {
+        return F.from_unixtime(ut);
+    } else {
+        return F.from_unixtime(ut, f);
+    }
+}
+
+/**
+ * Returns a Unix timestamp in seconds.
+ * If no arguments are passed, returns current time.
+ * If col is passed, it is parsed with the given format (see [http://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html]). The format defaults to (format yyyy-MM-dd HH:mm:ss).
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function unix_timestamp(s=null /*: Column*/, f=null /*: String*/) /*: Column*/ {
+    if (s === null) {
+        return F.unix_timestamp();
+    } else if (f === null) {
+        return F.unix_timestamp(s);
+    } else {
+        return F.unix_timestamp(s, f);
+    }
+}
+
+/**
+ * Converts the column into DateType.
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function to_date(e /*: Column*/) /*: Column*/ {
+    return F.to_date(col);
+}
+
+/**
+ * Returns date truncated to the unit specified by the format.
+ *
+ * @param format: 'year', 'yyyy', 'yy' for truncate by year,
+ *               or 'month', 'mon', 'mm' for truncate by month
+ *
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function trunc(date /*: Column*/, format /*: String*/) /*: Column*/ {
+    return F.trunc(datcol, format);
+}
+
+/**
+ * Assumes given timestamp is UTC and converts to given timezone.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function from_utc_timestamp(ts /*: Column*/, tz /*: String*/) /*: Column*/ {
+    return F.from_utc_timestamp(ts, tz);
+}
+
+/**
+ * Assumes given timestamp is in given timezone and converts to UTC.
+ * @group datetime_funcs
+ * @since 1.5.0
+ */
+function to_utc_timestamp(ts /*: Column*/, tz /*: String*/) /*: Column*/ {
+    return F.to_utc_timestamp(ts, tz);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Collection functions
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns true if the array contain the value
+ * @group collection_funcs
+ * @since 1.5.0
+ */
+function array_contains(column /*: Column*/, value /*: Any*/) /*: Column*/ {
+    return F.array_contains(column, value);
+}
+
+/**
+ * Creates a new row for each element in the given array or map column.
+ *
+ * @group collection_funcs
+ * @since 1.3.0
+ */
+function explode(e /*: Column*/) /*: Column*/ {
+    return F.explode(col);
+}
+
+/**
+ * Creates a new row for a json column according to the given field names.
+ *
+ * @group collection_funcs
+ * @since 1.6.0
+ */
+/* @scala.annotation.varargs */
+function json_tuple(json /*: Column*/, fields /*: String* */) /*: Column*/ {
+    return F.json_tuple(json, fields);
+}
+
+/**
+ * Returns length of array or map.
+ *
+ * @group collection_funcs
+ * @since 1.5.0
+ */
+function size(e /*: Column*/) /*: Column*/ {
+    return F.size(col);
+}
+
+/**
+ * Sorts the input array for the given column in ascending order,
+ * according to the natural ordering of the array elements.
+ *
+ * @group collection_funcs
+ * @since 1.5.0
+ */
+function sort_array(col /*: Column*/, asc=true /*: Boolean*/) /*: Column*/ {
+    return F.sort_array(col, asc);
+}

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var java = require('./java');
-
+var sqlContext = require('./sqlContext');
 
 function sparkConf(master, appName) {
     var SparkConf = java.import("org.apache.spark.SparkConf");
@@ -24,7 +24,7 @@ function spark_parseArgs(args) {
 
 }
 
-var sc, sqlc;
+var sc;
 
 
 
@@ -49,16 +49,11 @@ function sparkContext(args, assembly_jar) {
 }
 
 
-function sqlContext(args, assembly_jar) {
-    if (sqlc) return sqlc;
+function _sqlContext(args, assembly_jar) {
 
     var sc = sparkContext(args, assembly_jar);
 
-    var SQLContext = java.import("org.apache.spark.sql.SQLContext");
-
-    sqlc = new SQLContext(sc);
-
-    return sqlc;
+    return sqlContext(sc, java);
 }
 
 function sqlFunctions() {
@@ -67,6 +62,6 @@ function sqlFunctions() {
 
 module.exports = {
     sparkContext: sparkContext,
-    sqlContext: sqlContext,
+    sqlContext: _sqlContext,
     sqlFunctions: sqlFunctions
 }

--- a/lib/sqlContext.js
+++ b/lib/sqlContext.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var DataFrameReader = require('./DataFrameReader');
+var DataFrame = require('./DataFrame');
+var sc, sqlc, java;
+
+
+class SQLContext {
+
+    constructor(jvm_sqlContext) {
+        this.jvm_obj = jvm_sqlContext;
+        this.jvm_DataFrame = java.import('org.apache.spark.sql.DataFrame');
+    }
+
+    /**
+     * :: Experimental ::
+     * Returns a [[DataFrame]] with no rows or columns.
+     *
+     * @group basic
+     * @since 1.3.0
+     */
+    emptyDataFrame() {
+        return this.jvm_obj.emptyDataFrame();
+    }
+
+    /**
+     * :: Experimental ::
+     * Returns a [[DataFrameReader]] that can be used to read data in as a [[DataFrame]].
+     * {{{
+     *   sqlContext.read.parquet("/path/to/file.parquet")
+     *   sqlContext.read.schema(schema).json("/path/to/file.json")
+     * }}}
+     *
+     * @group genericdata
+     * @since 1.4.0
+     */
+    /* @Experimental */
+    read() {
+        return new DataFrameReader(this, java);
+    }
+
+
+    /**
+     * :: Experimental ::
+     * Creates a [[DataFrame]] with a single [[LongType]] column named `id`,
+     * containing elements in a range with step value 1. If end is provided, the
+     * range is from `start_or_end` to `end`. Otherwise it is from `0` to
+     * `start_or_end`.
+     *
+     * @since 1.4.1
+     * @group dataframe
+     */
+    /* @Experimental */
+    range (start_or_end, end=null, step=null) {
+        var start;
+        if (end === null) {
+            end = start_or_end;
+            start = 0;
+        } else {
+            start = start_or_end;
+        }
+
+        if (step === null) {
+            return this.jvm_obj.range(start, end);
+        } else {
+            return this.jvm_obj.range(start, end, step);
+        }
+    }
+
+    /**
+     * Executes a SQL query using Spark, returning the result as a [[DataFrame]]. The dialect that is
+     * used for SQL parsing can be configured with 'spark.sql.dialect'.
+     *
+     * @group basic
+     * @since 1.3.0
+     */
+    sql(sqlText /*: String*/) /*: DataFrame*/ {
+        var logicalPlan = this.jvm_obj.parseSql(sqlText);
+        var jvm_df = new this.jvm_DataFrame(this.jvm_obj, logicalPlan);
+        return new DataFrame(jvm_df, java);
+    }
+}
+
+function sqlContext(sc, java_) {
+    if (sqlc) return sqlc;
+
+    java = java_;
+    var jvm_SQLContext = java.import("org.apache.spark.sql.SQLContext");
+
+    sqlc = new jvm_SQLContext(sc);
+
+    return new SQLContext(sqlc);
+}
+
+module.exports = sqlContext;


### PR DESCRIPTION
This commit adds javascript modules/classes that wrap their scala
counterparts: SQLContext, DataFrame, DataFrameReader, GroupedData,
Row, and functions.

The wrappers are not complete: many of the scala functions/methods are not yet
exposed.