### PR TITLE
Add async APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ host volumes to use files on your host system with `spark-node`. For example
 
 will map the host's `/var/data` directory to `/data` within the Docker image. This means that you can use
 
-    $ var df = sqlContext.read().json("/data/people.json")
+    $ var df = sqlContext.read().jsonSync("/data/people.json")
 
 to load a file at `/var/data/people.json` on the host system.
 
@@ -113,7 +113,7 @@ To see available command-line options, do `./bin/spark-node --help`.
 
 Load a dataframe from a json file:
 
-    $ var df = sqlContext.read().json("./data/people.json")
+    $ var df = sqlContext.read().jsonSync("./data/people.json")
 
 Load a dataframe from a list of javascript objects:
 
@@ -196,7 +196,7 @@ Examples
 
 Create dataframe from text file:
 
-    $ var lines = sqlContext.read().text("data/words.txt");
+    $ var lines = sqlContext.read().textSync("data/words.txt");
 
 (_Note: support for the "text" format was added in Spark 1.6_).
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ or the shorter (equivalent) version:
 collect the result (as an array of rows) and assign it to a javascript
 variable:
 
-    $ var res = df.select("name").collect()
+    $ var res = df.select("name").collectSync()
 
 Select everybody and increment age by 1:
 

--- a/lib/DataFrame.js
+++ b/lib/DataFrame.js
@@ -54,14 +54,28 @@ class DataFrame {
 
     /**
      * Returns all column names as an array.
+     *
+     * @param cb Node-style callback function (error-first).
      * @since 1.3.0
      */
-    columns() /*: Array[String]*/ {
+    columns(cb /*: cb: (err: any, res: Array[String]) =>  any */) /*: void */ {
+        this.jvm_obj.columnsAsync(cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrame#columns}
+     * @since 1.3.0
+     */
+    columnsSync() /*: Array[String]*/ {
         return this.jvm_obj.columns();
     }
 
     /**
      * Prints the schema to the console in a nice tree format.
+     *
+     * This method runs a computation but is still synchronous, because it is
+     * used in an interactive setting (shell).
+     *
      * @since 1.3.0
      */
     printSchema() /*: Unit */ {
@@ -89,6 +103,9 @@ class DataFrame {
     /**
      * Displays the {@link DataFrame} in a tabular form. Strings more than 20 characters will be
      * truncated, and all cells will be aligned right.
+     *
+     * This method runs a computation but is still synchronous, because it is
+     * used in an interactive setting (shell).
      *
      * @param {Number} [numRows=20] Number of rows to show.
      *
@@ -413,14 +430,31 @@ class DataFrame {
     /**
      * Returns the first `n` rows.
      *
-     * Running take requires moving data into the application's driver process, and doing so with
+     * Running head requires moving data into the application's driver process, and doing so with
      * a very large `n` can crash the driver process with OutOfMemoryError.
+     *
+     * @param {Number} [n=1] Number of rows to return.
+     * @param cb Node-style callback function (error-first).
+     *
+     * @since 1.3.0
+     */
+    head(cb /*: cb: (err: any, res: Array[Object]) =>  any */, n=1 /*: Int */) /*: void */ {
+        let jvm_cb =  (err, jvm_rows) => {
+            if (err) return cb(err);
+            cb(err, jvm_rows.map(row => new Row(row).values()));
+        };
+
+        return this.jvm_obj.headAsync(n, jvm_cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrame#head}
      *
      * @param {Number} [n=1] Number of rows to return.
      *
      * @since 1.3.0
      */
-    head(n=1 /*: Int */) /*: Array[Object]*/ {
+    headSync(n=1 /*: Int */) /*: Array[Object]*/ {
         return this.jvm_obj.head(n)
             .map(row => new Row(row).values());
     }
@@ -431,18 +465,47 @@ class DataFrame {
      * Running collect requires moving all the data into the application's driver process, and
      * doing so on a very large dataset can crash the driver process with OutOfMemoryError.
      *
+     * @param cb Node-style callback function (error-first).
      * @since 1.3.0
      */
-    collect() /*: Array[Object]*/ {
+    collect(cb /*: cb: (err: any, res: Array[Object]) =>  any */) /*: void*/ {
+        let jvm_cb =  (err, jvm_rows) => {
+            if (err) return cb(err);
+            cb(err, jvm_rows.map(row => new Row(row).values()));
+        };
+        this.jvm_obj.collectAsync(jvm_cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrame#collect}
+     *
+     * @since 1.3.0
+     */
+    collectSync() /*: Array[Object]*/ {
         return this.jvm_obj.collect()
             .map(row => new Row(row).values());
     }
 
     /**
      * Returns the number of rows in the {@link DataFrame}.
+     *
+     * @param cb Node-style callback function (error-first).
      * @since 1.3.0
      */
-    count() /*: Number */ {
+    count(cb /*: cb: (err: any, res: Number) =>  any */) /*: void*/ {
+        let jvm_cb = (err, res) => {
+            if (err) return cb(err);
+            cb(err, res.valueOf());
+        };
+
+        this.jvm_obj.countAsync(jvm_cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrame#count}
+     * @since 1.3.0
+     */
+    countSync() /*: Number */ {
         return this.jvm_obj.count().valueOf();
     }
 

--- a/lib/DataFrameReader.js
+++ b/lib/DataFrameReader.js
@@ -58,7 +58,7 @@ class DataFrameReader {
      * @param value
      * @since 1.4.0
      */
-    option(key /*: String */, value /*: String */) {
+    option(key /*: String */, value /*: String */) /*: DataFrameReader */{
         this.jvm_obj.option(key, value);
         return this;
     }

--- a/lib/DataFrameReader.js
+++ b/lib/DataFrameReader.js
@@ -42,13 +42,17 @@ class DataFrameReader {
      * @param [path=null] Optional path for file-system backed data sources.
      * @since 1.4.0
      */
-    load(path=null /*: String */)/*: DataFrame */ {
-        if (path === null) {
-            return new DataFrame(this.jvm_obj.load());
-        } else {
-            this.option("path", path);
-            return this.load();
-        }
+    load(path /*: String */, cb /*: cb: (err: any, res: DataFrame) => any */) /*: void */ {
+        this.option("path", path);
+        this.jvm_obj.loadAsync((err, jvm_df) => {
+            if (err) return cb(err);
+            cb(err, new DataFrame(jvm_df));
+        });
+    }
+
+    loadSync(path /*: String */)/*: DataFrame */ {
+        this.option("path", path);
+        return new DataFrame(this.jvm_obj.load());
     }
 
     /**
@@ -78,10 +82,21 @@ class DataFrameReader {
      * (e.g. 00012)</li>
      *
      * @param path
+     * @param cb Node-style callback function (error-first).
      * @since 1.4.0
      */
-    json(path /*: String */)/*: DataFrame */ {
-        return this.format("json").load(path);
+    json(path /*: String */, cb /*: cb: (err: any, res: DataFrame) => any */)/*: void */ {
+        this.format("json").load(path, cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrameReader#json}
+     *
+     * @param path
+     * @since 1.4.0
+     */
+    jsonSync(path /*: String */)/*: DataFrame */ {
+        return this.format("json").loadSync(path);
     }
 
     jsonRDD_(jrdd /*: javaRDD[String] */) /*: DataFrame */ {
@@ -93,11 +108,22 @@ class DataFrameReader {
      * column named "text". Each line in the text file is a new row in the
      * resulting DataFrame.
      *
+     * @param cb Node-style callback function (error-first).
      * @param path
      * @since 1.6.0
      */
-    text(path /*: String */)/*: DataFrame */ {
-        return this.format("text").load(path);
+    text(path /*: String */, cb /*: cb: (err: any, res: DataFrame) => any */)/*: DataFrame */ {
+        return this.format("text").load(path, cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrameReader#text}
+     *
+     * @param path
+     * @since 1.6.0
+     */
+    textSync(path /*: String */)/*: DataFrame */ {
+        return this.format("text").loadSync(path);
     }
 }
 

--- a/lib/DataFrameWriter.js
+++ b/lib/DataFrameWriter.js
@@ -83,17 +83,20 @@ class DataFrameWriter {
      * Saves the content of the {@link DataFrame} at the specified path.
      *
      * @private
+     * @param cb Node-style callback function (error-first).
      * @param [path=null]
      * @since 1.4.0
      */
-    save(path=null /*: String */) /*: Unit */ {
-        if (path === null) {
-            this.jvm_obj.save();
-        } else {
-            this.option("path", path);
-            this.save();
-        }
+    save(path /*: String */, cb /*: cb: (err: any) => any */) /*: void */ { //
+        this.option("path", path);
+        this.jvm_obj.saveAsync(cb);
     }
+
+    saveSync(path /*: String */) /*: void */ {
+        this.option("path", path);
+        this.jvm_obj.save();
+    }
+
 
     /**
      * Inserts the content of the {@link DataFrame} to the specified table. It
@@ -103,10 +106,21 @@ class DataFrameWriter {
      * Because it inserts data to an existing table, format or options will be
      * ignored.
      *
+     * @param cb Node-style callback function (error-first).
      * @param tableName
      * @since 1.4.0
      */
-    insertInto(tableName /*: String */) /*: Unit */ {
+    insertInto(tableName /*: String */, cb /*: cb: (err: any) => any */) /*: void */ {
+        this.jvm_obj.insertIntoAsync(tableName, cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrameWriter#insertInto}
+     *
+     * @param tableName
+     * @since 1.4.0
+     */
+    insertIntoSync(tableName /*: String */) /*: void */ {
         this.jvm_obj.insertInto(tableName);
     }
 
@@ -131,7 +145,17 @@ class DataFrameWriter {
      * @param tableName
      * @since 1.4.0
      */
-    saveAsTable(tableName /*: String */) /*: Unit */ {
+    saveAsTable(tableName /*: String */, cb /*: cb: (err: any) => any */) /*: void */ {
+        this.jvm_obj.saveAsTableAsync(tableName, cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrameWriter#saveAsTable}
+     *
+     * @param tableName
+     * @since 1.4.0
+     */
+    saveAsTableSync(tableName /*: String */) /*: void */ {
         this.jvm_obj.saveAsTable(tableName);
     }
 
@@ -163,9 +187,21 @@ class DataFrameWriter {
      * Saves the content of the {@link DataFrame} in JSON format at the specified
      * path.
      *
+     * @param cb Node-style callback function (error-first).
+     *
      * @since 1.4.0
      */
-    json(path /*: String */) /*: Unit */ {
+    json(path /*: String */, cb /*: cb: (err: any)*/) /*: Unit */ {
+        this.jvm_obj.format("json").saveAsync(path, cb);
+    }
+
+    /**
+     *
+     * The synchronous version of {@link DataFrameWriter#json}
+     *
+     * @since 1.4.0
+     */
+    jsonSync(path /*: String */) /*: void */ {
         this.jvm_obj.format("json").save(path);
     }
 
@@ -174,12 +210,24 @@ class DataFrameWriter {
      * path.  The DataFrame must have only one column that is of string type.
      * Each row becomes a new line in the output file.
      *
-     *
      * @example
-     * df.write().text("/path/to/output")
+     * df.write().text("/path/to/output", cb)
+     *
+     * @param cb Node-style callback function (error-first).
+     * @param path
      * @since 1.6.0
      */
-    text(path /*: String */) /*: Unit */ {
+    text(path /*: String */, cb /*: cb: (err: any) => any */) /*: void */ {
+        this.jvm_obj.format("text").saveAsync(path, cb);
+    }
+
+    /**
+     * The synchronous version of {@link DataFrameWriter#text}
+     *
+     * @param path
+     * @since 1.6.0
+     */
+    textSync(path /*: String */) /*: void */ {
         this.jvm_obj.format("text").save(path);
     }
 

--- a/lib/java.js
+++ b/lib/java.js
@@ -4,8 +4,8 @@ var path = require("path");
 var java = require("java");
 
 java.asyncOptions = {
-    syncSuffix: "",           // Synchronous methods the base name
-    asyncSuffix: undefined,   // don't generate async (callback-style) wrappers
+    syncSuffix: "",           // Synchronous methods use the base name
+    asyncSuffix: "Async",     // Async methods
     promiseSuffix: undefined  // don't generate promise wrappers
 };
 

--- a/lib/sqlContext.js
+++ b/lib/sqlContext.js
@@ -52,7 +52,7 @@ class SQLContext {
      * @param [step=1] Step.
      * @since 1.4.1
      */
-    range(start_or_end, end=null, step=1) {
+    range(start_or_end /*: Number */ , end=null /*: Number */, step=1 /*: Number */) /*: DataFrame */{
         var start, par;
         if (end === null) {
             end = start_or_end;

--- a/test/SQLContext.js
+++ b/test/SQLContext.js
@@ -19,8 +19,11 @@ describe("SQLContext", function() {
     it("emptyDataFrame() returns df with 0 rows", function(done) {
         var df = sqlContext.emptyDataFrame();
         expect(df).to.be.an.instanceof(DataFrame);
-        expect(df.count()).to.equal(0);
-        done();
+        df.count(function(err, res) {
+            expect(err).to.be.undefined;
+            expect(res).to.equal(0);
+            done();
+        });
     });
 
     it("read() returns a DataFrameReader", function(done) {
@@ -31,26 +34,30 @@ describe("SQLContext", function() {
 
     it("range(3) returns a DataFrame with 0..2", function(done) {
         var df = sqlContext.range(3);
-        var values = df.collect();
+        df.collect(function(err, res) {
+            expect(err).to.be.undefined;
+            expect(res).to.deep.equal([[0], [1], [2]]);
+            done();
+        });
 
-        expect(values).to.deep.equal([[0], [1], [2]]);
-        done();
     });
 
     it("range(1, 4, 2) returns a DataFrame with 1,3", function(done) {
         var df = sqlContext.range(1, 4, 2);
-        var values = df.collect();
-
-        expect(values).to.deep.equal([[1], [3]]);
-        done();
+        df.collect(function(err, res) {
+            expect(err).to.be.undefined;
+            expect(res).to.deep.equal([[1], [3]]);
+            done();
+        });
     });
 
     it("createDataFrame([{a: 1}, {b: 2}])", function(done) {
         var df = sqlContext.createDataFrame([{a: 1}, {b: 2}]);
-        var values = df.collect();
-
-        expect(values).to.deep.equal([[ 1, null ], [ null, 2 ]]);
-        done();
+        df.collect(function(err, res) {
+            expect(err).to.be.undefined;
+            expect(res).to.deep.equal([[ 1, null ], [ null, 2 ]]);
+            done();
+        });
     });
 
     it("sql(..) with simple SELECT statement", function(done) {
@@ -60,11 +67,11 @@ describe("SQLContext", function() {
 
         var df = sqlContext.createDataFrame(people);
         df.registerTempTable("people");
-        var values = sqlContext.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19").collect();
-
-        expect(values).to.deep.equal([["Justin"]]);
-        done();
+        sqlContext.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19").collect(
+            function(err, res) {
+                expect(err).to.be.undefined;
+                expect(res).to.deep.equal([["Justin"]]);
+                done();
+            });
     });
-
-
 });

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -20,21 +20,33 @@ describe("Smoke test", function() {
     });
 
     it("sqlContext.read().json() returns DataFrame", function(done) {
-        var df = sqlContext.read().json(path.join(__dirname, "..", "data/people.json"));
+        sqlContext.read().json(path.join(__dirname, "..", "data/people.json"), function(err, res) {
+            expect(err).to.be.undefined;
+            expect(res).to.be.an.instanceof(DataFrame);
+            done();
+        });
+    });
+
+    it("sqlContext.read().jsonSync() returns DataFrame", function(done) {
+        var df = sqlContext.read().jsonSync(path.join(__dirname, "..", "data/people.json"));
         expect(df).to.be.an.instanceof(DataFrame);
         done();
     });
 
     it("sqlContext.read().collect() returns array of Rows with correct values", function(done) {
-        sqlContext.read().json("./data/people.json").collect(function(err, rows) {
-            rows.forEach(function (row) { expect(row).to.be.an.instanceof(Object);});
-            expect(rows).to.deep.equal([[null, "Michael"], [30, "Andy"], [19, "Justin"]]);
-            done();
+        sqlContext.read().json("./data/people.json", function (err, df) {
+            expect(err).to.be.undefined;
+            df.collect(function(err, rows) {
+                expect(err).to.be.undefined;
+                rows.forEach(function (row) { expect(row).to.be.an.instanceof(Object);});
+                expect(rows).to.deep.equal([[null, "Michael"], [30, "Andy"], [19, "Justin"]]);
+                done();
+            });
         });
     });
 
     it("sqlContext.read().collectSync() returns array of Rows with correct values", function(done) {
-        var rows = sqlContext.read().json("./data/people.json").collectSync();
+        var rows = sqlContext.read().jsonSync("./data/people.json").collectSync();
 
         rows.forEach(function (row) { expect(row).to.be.an.instanceof(Object);});
 
@@ -52,8 +64,8 @@ describe("Smoke test", function() {
             done();
         });
 
-        it("var df = sqlContext.read().json(\"data/people.json\");", function(done) {
-            df = sqlContext.read().json(path.join(__dirname, "..", "data/people.json"));
+        it("var df = sqlContext.read().jsonSync(\"data/people.json\");", function(done) {
+            df = sqlContext.read().jsonSync(path.join(__dirname, "..", "data/people.json"));
             expect(df).to.be.an.instanceof(DataFrame);
             done();
         });
@@ -209,7 +221,7 @@ describe("Smoke test", function() {
         it("check counts ", function(done) {
 
             var sqlContext = spark([], process.env.ASSEMBLY_JAR).sqlContext;
-            var lines = sqlContext.read().text(path.join(__dirname, "..", "data/words.txt"));
+            var lines = sqlContext.read().textSync(path.join(__dirname, "..", "data/words.txt"));
             var F = spark([], process.env.ASSEMBLY_JAR).sqlFunctions;
             var splits = lines.select(F.split(lines.col("value"), " ").as("words"));
             var occurrences = splits.select(F.explode(splits.col("words")).as("word"));

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -26,7 +26,15 @@ describe("Smoke test", function() {
     });
 
     it("sqlContext.read().collect() returns array of Rows with correct values", function(done) {
-        var rows = sqlContext.read().json("./data/people.json").collect();
+        sqlContext.read().json("./data/people.json").collect(function(err, rows) {
+            rows.forEach(function (row) { expect(row).to.be.an.instanceof(Object);});
+            expect(rows).to.deep.equal([[null, "Michael"], [30, "Andy"], [19, "Justin"]]);
+            done();
+        });
+    });
+
+    it("sqlContext.read().collectSync() returns array of Rows with correct values", function(done) {
+        var rows = sqlContext.read().json("./data/people.json").collectSync();
 
         rows.forEach(function (row) { expect(row).to.be.an.instanceof(Object);});
 
@@ -107,8 +115,8 @@ describe("Smoke test", function() {
             done();
         });
 
-        it("var res = df.select(\"name\").collect()", function(done) {
-            var res = df.select("name").collect();
+        it("var res = df.select(\"name\").collectSync()", function(done) {
+            var res = df.select("name").collectSync();
             expect(res).to.deep.equal([["Michael"], ["Andy"], ["Justin"]]);
             done();
         });


### PR DESCRIPTION
#26 

This is a breaking change that transforms all methods that "run computation" from synchronous to asynchronous (node-style callback) operation. The existing synchronous methods are renamed with a "Sync" suffix. 

The methods converted are:
```
DataFrame.collect(..)
DataFrame.columns(..)
DataFrame.count(..)
DataFrame.head(..)

DataFrameReader.json(..)
DataFrameReader.text(..)

DataFrameWriter.json(..)
DataFrameWriter.text(..)
DataFrameWriter.saveAsTable(..)
DataFrameWriter.insertInto(..)
```




