### PR TITLE
Refactoring, so that the the module can be used independently.

### DIFF
--- a/bin/spark-node
+++ b/bin/spark-node
@@ -7,7 +7,7 @@ process.title = "spark-node";
 var repl = require("repl");
 
 var spark_node = require("../");
-var context = spark_node();
+var context = spark_node(process.argv.slice(2));
 
 global.sqlContext= context.sqlContext;
 global.sqlFunctions = context.sqlFunctions;

--- a/bin/spark-node
+++ b/bin/spark-node
@@ -2,32 +2,12 @@
 /*eslint-disable no-console*/
 "use strict";
 
-var fs = require("fs");
-var path = require("path");
-
 process.title = "spark-node";
 
 var repl = require("repl");
 
 var spark_node = require("../");
-var args =
-        // fake presence of a main class so that SparkSubmitArguments doesn't
-        // bail. (It won't be run)
-        ["--class", "org.apache.spark.repl.Main",
-         "--name", "spark-node shell"]
-        .concat(
-            process.argv.slice(2) // remove 'node spark-node'
-        )
-        .concat(["spark-shell"]);
-
-var assembly_jar = process.env.ASSEMBLY_JAR;
-
-if (typeof assembly_jar != "string" || !fs.statSync(path.join(assembly_jar)).isFile()) {
-    console.error("Error: ASSEMBLY_JAR environment variable does not contain valid path");
-    process.exit(1);
-}
-
-var context = spark_node(args, assembly_jar);
+var context = spark_node();
 
 global.sqlContext= context.sqlContext;
 global.sqlFunctions = context.sqlFunctions;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,30 @@
 "use strict";
 
+var fs = require("fs");
+var path = require("path");
+
 var spark = require("./js");
 var functions = require("./js/functions");
 
-
 module.exports = function (args, assembly_jar) {
+
+    var args =
+        // fake presence of a main class so that SparkSubmitArguments doesn't
+        // bail. (It won't be run)
+        ["--class", "org.apache.spark.repl.Main",
+            "--name", "spark-node shell"]
+            .concat(
+                process.argv.slice(2) // remove 'node spark-node'
+            )
+            .concat(["spark-shell"]);
+
+    var assembly_jar = process.env.ASSEMBLY_JAR;
+
+    if (typeof assembly_jar != "string" || !fs.statSync(path.join(assembly_jar)).isFile()) {
+        console.error("Error: ASSEMBLY_JAR environment variable does not contain valid path");
+        process.exit(1);
+    }
+
     return {
         // don't expose sparkcontext until/if we support RDD's
         // sparkContext: spark.sparkContext(args, assembly_jar),

--- a/index.js
+++ b/index.js
@@ -6,16 +6,14 @@ var path = require("path");
 var spark = require("./js");
 var functions = require("./js/functions");
 
-module.exports = function (args, assembly_jar) {
+module.exports = function (args) {
 
     var args =
         // fake presence of a main class so that SparkSubmitArguments doesn't
         // bail. (It won't be run)
         ["--class", "org.apache.spark.repl.Main",
             "--name", "spark-node shell"]
-            .concat(
-                process.argv.slice(2) // remove 'node spark-node'
-            )
+            .concat(args)
             .concat(["spark-shell"]);
 
     var assembly_jar = process.env.ASSEMBLY_JAR;


### PR DESCRIPTION
With this refactoring, it is possible to use this module in other projects, i.e. `bin/spark-node` is "just" the REPL interface to the Spark context.