### PR TITLE
Fix some DataFrame methods

### DIFF
--- a/lib/DataFrame.js
+++ b/lib/DataFrame.js
@@ -140,10 +140,10 @@ class DataFrame {
      */
     join(right /*: DataFrame */, col=null /*: Column|String */, joinType="inner" /*: String*/) /*: DataFrame */ {
         if (col === null) {
-            return new DataFrame(this.jvm_obj.join(right));
+            return new DataFrame(this.jvm_obj.join(right.jvm_obj));
         } else {
             col = helpers.jobj_from_maybe_string(col);
-            return new DataFrame(this.jvm_obj.join(right, col, joinType));
+            return new DataFrame(this.jvm_obj.join(right.jvm_obj, col, joinType));
         }
     }
 
@@ -297,7 +297,7 @@ class DataFrame {
      * @since 1.3.0
      */
     unionAll(other /*: DataFrame */) /*: DataFrame */ {
-        return new DataFrame(this.jvm_obj.unionAll(other));
+        return new DataFrame(this.jvm_obj.unionAll(other.jvm_obj));
     }
 
     /**
@@ -307,7 +307,7 @@ class DataFrame {
      * @since 1.3.0
      */
     intersect(other /*: DataFrame */) /*: DataFrame */ {
-        return new DataFrame(this.jvm_obj.intersect(other));
+        return new DataFrame(this.jvm_obj.intersect(other.jvm_obj));
     }
 
     /**
@@ -317,7 +317,7 @@ class DataFrame {
      * @since 1.3.0
      */
     except(other /*: DataFrame */) /*: DataFrame */ {
-        return new DataFrame(this.jvm_obj.except(other));
+        return new DataFrame(this.jvm_obj.except(other.jvm_obj));
     }
 
     /**


### PR DESCRIPTION
Fix a few places where underlying jvm methods were being called with the
javascript DataFrame object rather than the handle to the underlying jvm
object.

Fixes #34.